### PR TITLE
Adds feature flags for libraries that require C bindungs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ time = { version = "0.3.21", features = ["serde-human-readable"] }
 
 [features]
 unstable_generic_http_client = []
+with_truck_simulator = []
+with_r3e = []
+
+default = ["with_r3e", "with_truck_simulator"]
 
 [dependencies.tokio]
 version = "1.24.1"

--- a/build.rs
+++ b/build.rs
@@ -2,34 +2,38 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    println!("cargo:rerun-if-changed=src/raceroom_racing_experience/r3e.h");
+    #[cfg(feature = "with_r3e")] {
+        println!("cargo:rerun-if-changed=src/raceroom_racing_experience/r3e.h");
 
-    let bindings = bindgen::Builder::default()
-        .header("src/raceroom_racing_experience/r3e.h")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-        .derive_partialeq(true)
-        .derive_eq(true)
-        .derive_hash(true)
-        .generate()
-        .expect("Unable to generate bindings");
+        let bindings = bindgen::Builder::default()
+            .header("src/raceroom_racing_experience/r3e.h")
+            .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+            .derive_partialeq(true)
+            .derive_eq(true)
+            .derive_hash(true)
+            .generate()
+            .expect("Unable to generate bindings");
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("r3e.rs"))
-        .expect("Couldn't write bindings!");
+        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+        bindings
+            .write_to_file(out_path.join("r3e.rs"))
+            .expect("Couldn't write bindings!");
+    }
 
-    let bindings = bindgen::Builder::default()
-        .header("src/truck_simulator/scs-sdk-plugin/scssdk.h")
-        .header("src/truck_simulator/scs-sdk-plugin/scs-telemetry-common.hpp")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-        .derive_partialeq(true)
-        .derive_eq(true)
-        .derive_hash(true)
-        .generate()
-        .expect("Unable to generate bindings");
+    #[cfg(feature = "with_truck_simulator")] {
+        let bindings = bindgen::Builder::default()
+            .header("src/truck_simulator/scs-sdk-plugin/scssdk.h")
+            .header("src/truck_simulator/scs-sdk-plugin/scs-telemetry-common.hpp")
+            .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+            .derive_partialeq(true)
+            .derive_eq(true)
+            .derive_hash(true)
+            .generate()
+            .expect("Unable to generate bindings");
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("scs_telemetry_common.rs"))
-        .expect("Couldn't write bindings!");
+        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+        bindings
+            .write_to_file(out_path.join("scs_telemetry_common.rs"))
+            .expect("Couldn't write bindings!");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,11 @@ pub mod dirt_rally_2;
 #[cfg(feature = "unstable_generic_http_client")]
 pub mod generic_http;
 pub mod iracing;
+#[cfg(feature = "with_r3e")]
 pub mod raceroom_racing_experience;
 mod racing_flags;
 pub mod rfactor_2;
+#[cfg(feature = "with_truck_simulator")]
 pub mod truck_simulator;
 mod windows_util;
 
@@ -71,17 +73,23 @@ impl SimetryConnectionBuilder {
         let assetto_corsa_future = assetto_corsa::Client::connect(retry_delay);
         let assetto_corsa_competizione_future =
             assetto_corsa_competizione::Client::connect(retry_delay);
-        let raceroom_racing_experience_future =
+        #[cfg(feature = "with_r3e")]
+            let raceroom_racing_experience_future =
             raceroom_racing_experience::Client::connect(retry_delay);
+        #[cfg(not(feature = "with_r3e"))]
+            let raceroom_racing_experience_future = never_resolved();
         let rfactor_2_future = rfactor_2::Client::connect();
         let dirt_rally_2_future =
             dirt_rally_2::Client::connect(&self.dirt_rally_2_uri, retry_delay);
         #[cfg(feature = "unstable_generic_http_client")]
-        let generic_http_future =
+            let generic_http_future =
             generic_http::GenericHttpClient::connect(&self.generic_http_uri, retry_delay);
         #[cfg(not(feature = "unstable_generic_http_client"))]
-        let generic_http_future = never_resolved();
-        let truck_simulator_future = truck_simulator::Client::connect(retry_delay);
+            let generic_http_future = never_resolved();
+        #[cfg(feature = "with_truck_simulator")]
+            let truck_simulator_future = truck_simulator::Client::connect(retry_delay);
+        #[cfg(not(feature = "with_truck_simulator"))]
+            let truck_simulator_future = never_resolved();
 
         select! {
             x = iracing_future => Box::new(x),

--- a/src/truck_simulator/bindings.rs
+++ b/src/truck_simulator/bindings.rs
@@ -6,4 +6,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+#[cfg(feature = "with_truck_simulator")]
 include!(concat!(env!("OUT_DIR"), "/scs_telemetry_common.rs"));
+

--- a/src/truck_simulator/mod.rs
+++ b/src/truck_simulator/mod.rs
@@ -102,7 +102,7 @@ impl SimState {
                 .map_while(|v| if *v < 32 { None } else { Some(*v as u8) })
                 .collect(),
         )
-        .unwrap()
+            .unwrap()
     }
 }
 


### PR DESCRIPTION
Great library, thank for creating it!

This PR is to ensure the library can be compiled with the feature flags off when those headers (r3e/euro truck) are not in place.
By default the behavior is not changed.